### PR TITLE
Changing default width to 1200 pixels

### DIFF
--- a/app/assets/stylesheets/swagger_engine/screen.css
+++ b/app/assets/stylesheets/swagger_engine/screen.css
@@ -123,7 +123,7 @@
 .swagger-section .swagger-ui-wrap {
   line-height: 1;
   font-family: "Droid Sans", sans-serif;
-  max-width: 1280px;
+  max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
   /* JSONEditor specific styling */

--- a/app/assets/stylesheets/swagger_engine/screen.css
+++ b/app/assets/stylesheets/swagger_engine/screen.css
@@ -123,7 +123,7 @@
 .swagger-section .swagger-ui-wrap {
   line-height: 1;
   font-family: "Droid Sans", sans-serif;
-  max-width: 960px;
+  max-width: 1280px;
   margin-left: auto;
   margin-right: auto;
   /* JSONEditor specific styling */


### PR DESCRIPTION
Standard width of 960 causes awkward wrapping. 1280 looks better.